### PR TITLE
Ensure ReportGenerator is available during coverage steps

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -236,6 +236,7 @@ stages:
         buildPlatform: '$(buildConfiguration)'
 
     - script: |
+        export PATH="$PATH:$HOME/.dotnet/tools"
         reportgenerator -reports:"$(Build.SourcesDirectory)/**/coverage.cobertura.xml" -targetdir:"$(coverageReportDir)" -reporttypes:"Cobertura;HtmlInline_AzurePipelines;TextSummary"
       displayName: 'Generate coverage reports'
 
@@ -305,6 +306,7 @@ stages:
       displayName: 'Run full test suite with coverage'
 
     - script: |
+        export PATH="$PATH:$HOME/.dotnet/tools"
         reportgenerator -reports:"$(Build.SourcesDirectory)/**/coverage.cobertura.xml" -targetdir:"$(coverageReportDir)" -reporttypes:"Cobertura;HtmlInline_AzurePipelines;TextSummary"
       displayName: 'Generate coverage reports'
 


### PR DESCRIPTION
## Summary
- export the dotnet tools directory onto PATH before invoking ReportGenerator in coverage steps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbb5e9c6c0832fb705920bcf7ef11b