### PR TITLE
Install ReportGenerator tool in temp directory

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,14 +43,24 @@ stages:
     - pwsh: |
         $ErrorActionPreference = 'Stop'
 
-        dotnet tool update --global dotnet-reportgenerator-globaltool 2>$null
-        if ($LASTEXITCODE -ne 0) {
-          dotnet tool install --global dotnet-reportgenerator-globaltool
+        $toolInstallRoot = if ($env:AGENT_TEMPDIRECTORY) {
+          Join-Path $env:AGENT_TEMPDIRECTORY '.dotnet-tools'
+        } elseif ($env:HOME) {
+          Join-Path $env:HOME '.dotnet-tools'
+        } elseif ($env:USERPROFILE) {
+          Join-Path $env:USERPROFILE '.dotnet-tools'
+        } else {
+          throw 'Unable to determine a writable tool installation directory.'
         }
 
-        $home = if ($env:HOME) { $env:HOME } else { $env:USERPROFILE }
-        $dotnetFolder = Join-Path $home '.dotnet'
-        $toolPath = Join-Path $dotnetFolder 'tools'
+        New-Item -ItemType Directory -Path $toolInstallRoot -Force | Out-Null
+
+        dotnet tool update --tool-path $toolInstallRoot dotnet-reportgenerator-globaltool 2>$null
+        if ($LASTEXITCODE -ne 0) {
+          dotnet tool install --tool-path $toolInstallRoot dotnet-reportgenerator-globaltool
+        }
+
+        $toolPath = $toolInstallRoot
         Write-Host "##vso[task.prependpath]$toolPath"
       displayName: 'Install ReportGenerator tool'
 


### PR DESCRIPTION
## Summary
- install ReportGenerator as a local tool in the agent temp directory instead of relying on $HOME
- ensure the tool path directory is created and added to PATH

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbc7260adc832fbb4fa6c88a064524