### PR TITLE
Fix PowerShell condition when checking project paths

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -330,9 +330,10 @@ stages:
         $history = git rev-list --max-count=2 HEAD
         $previousCommit = ($history | Select-Object -Last 1)
 
-        if (-not $previousCommit) {
-          Write-Host 'Only one commit detected on branch. All projects will be considered changed.'
-          $changedPaths = git ls-files '*.csproj'
+        if ([string]::IsNullOrWhiteSpace($previousCommit) -or $previousCommit -eq $currentCommit) {
+          Write-Host 'Only one commit detected on branch or unable to resolve previous commit. All tracked files will be evaluated.'
+          $changedPaths = git ls-files
+          $previousCommit = $null
         }
         else {
           Write-Host "Current commit: $currentCommit"
@@ -340,7 +341,17 @@ stages:
           $changedPaths = git diff --name-only $previousCommit $currentCommit
         }
 
-        $changedPaths = $changedPaths | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+        $changedPaths = $changedPaths | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Sort-Object -Unique
+
+        if ($previousCommit) {
+          if ($changedPaths) {
+            Write-Host 'Detected the following paths changed between the last two commits:'
+            $changedPaths | ForEach-Object { Write-Host " - $_" }
+          }
+          else {
+            Write-Host 'No file changes were detected between the last two commits.'
+          }
+        }
 
         if (-not $changedPaths) {
           Write-Host 'No project changes detected. Skipping deployment phase.'
@@ -367,7 +378,15 @@ stages:
         $projectsToDeploy = New-Object System.Collections.Generic.HashSet[string]
         foreach ($path in $changedPaths) {
           $proj = Get-ProjectRoot $path
-          if ($proj) { $projectsToDeploy.Add($proj) | Out-Null }
+          if ($proj) {
+            if (-not $projectsToDeploy.Contains($proj)) {
+              Write-Host "Mapped changed path '$path' to project '$proj'"
+            }
+            $projectsToDeploy.Add($proj) | Out-Null
+          }
+          else {
+            Write-Host "No deployable project mapping found for changed path '$path'"
+          }
         }
 
         if ($projectsToDeploy.Count -eq 0) {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -337,8 +337,10 @@ stages:
         else {
           Write-Host "Current commit: $currentCommit"
           Write-Host "Previous commit: $previousCommit"
-          $changedPaths = git diff --name-only $previousCommit $currentCommit -- '*.csproj' '*.cs'
+          $changedPaths = git diff --name-only $previousCommit $currentCommit
         }
+
+        $changedPaths = $changedPaths | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
 
         if (-not $changedPaths) {
           Write-Host 'No project changes detected. Skipping deployment phase.'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -348,7 +348,7 @@ stages:
 
         function Get-ProjectRoot([string]$path) {
           $fullPath = Join-Path '$(Build.SourcesDirectory)' $path
-          if (Test-Path $fullPath -PathType Leaf -and $fullPath.EndsWith('.csproj')) {
+          if ((Test-Path $fullPath -PathType Leaf) -and $fullPath.EndsWith('.csproj')) {
             return $fullPath
           }
           $directory = Split-Path $fullPath -Parent


### PR DESCRIPTION
## Summary
- fix the PowerShell condition in the deployment plan script so Test-Path and string checks are evaluated correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbd99895b0832fbc8efcde9f4482f3